### PR TITLE
Make all fields optional in hook types

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -61,17 +61,9 @@ export type Method = 'find' | 'get' | 'create' | 'update' | 'patch' | 'remove'
 export type Type = 'before' | 'after' | 'error'
 
 export interface GraphPopulateHookMap {
-  all: SingleGraphPopulateParams[];
-  find: SingleGraphPopulateParams[];
-  get: SingleGraphPopulateParams[];
-  create: SingleGraphPopulateParams[];
-  update: SingleGraphPopulateParams[];
-  patch: SingleGraphPopulateParams[];
-  remove: SingleGraphPopulateParams[];
+  [key in Method | 'all']: SingleGraphPopulateParams[];
 }
 
 export interface GraphPopulateHooksObject {
-  before: GraphPopulateHookMap;
-  after: GraphPopulateHookMap;
-  error: GraphPopulateHookMap;
+  [key in Type]: GraphPopulateHookMap;
 }


### PR DESCRIPTION
Hello,

I noticed that the types insisted having hooks for every possible case, which wasn't really required when using without types. So I made them optional in the types too.

Is it also okay to extend ServiceAddons with 'graphPopulate' like how it's done with Application?